### PR TITLE
Add trailing #/ if needed

### DIFF
--- a/lib/yaml_ref_resolver.rb
+++ b/lib/yaml_ref_resolver.rb
@@ -21,7 +21,7 @@ class YamlRefResolver
 
     @yaml[abs_path] = YAML.load_file(abs_path)
     find_refs(@yaml[abs_path]).each do |ref_target|
-      rel_path, pos = ref_target.split('#')
+      rel_path, pos = parse_ref(ref_target)
       preload_ref_yamls(File.expand_path(rel_path, File.dirname(abs_path)))
     end
   end
@@ -53,7 +53,7 @@ class YamlRefResolver
   def resolve_hash(hash, referrer)
     resolved = hash.map do |key, val|
       if key == @key
-        path, pos = val.split('#')
+        path, pos = parse_ref(val)
         ref_path = File.expand_path(path, File.dirname(referrer))
         pos_keys = pos.split('/').reject {|s| s == "" }
 
@@ -72,5 +72,15 @@ class YamlRefResolver
 
   def resolve_array(array, referrer)
     array.map {|e| resolve_refs(e, referrer) }
+  end
+
+  def parse_ref(ref)
+    splitted = ref.split('#')
+
+    if splitted.size == 1
+      splitted << '/'
+    else
+      splitted
+    end
   end
 end

--- a/lib/yaml_ref_resolver/version.rb
+++ b/lib/yaml_ref_resolver/version.rb
@@ -1,3 +1,3 @@
 class YamlRefResolver
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end

--- a/test/yaml_ref_resolver_test.rb
+++ b/test/yaml_ref_resolver_test.rb
@@ -48,4 +48,12 @@ class YamlRefResolverTest < Minitest::Test
 
     assert_equal yaml['paths']['/products']['post']['tags'].first, 'product'
   end
+
+  def test_hash_slash_completion
+    path = File.join(File.dirname(__FILE__), *%w[yamls completion index.yaml])
+    yaml = @resolver.resolve(path)
+
+    assert_equal yaml['produces'][0], 'application/json'
+    assert_equal yaml['produces'][1], 'text/html'
+  end
 end

--- a/test/yamls/completion/index.yaml
+++ b/test/yamls/completion/index.yaml
@@ -1,0 +1,11 @@
+swagger: '2.0'
+info:
+  title: Sample API
+  description: This is a sample swagger yaml
+  version: "1.0.0"
+host: api.sample.com
+schemes:
+  - https
+basePath: /v1
+produces:
+  $ref: './produces.yaml'

--- a/test/yamls/completion/produces.yaml
+++ b/test/yamls/completion/produces.yaml
@@ -1,0 +1,2 @@
+- application/json
+- text/html


### PR DESCRIPTION
### What to do

Previous implementation premised that there always is path specification like `#/User/name` after ref yaml path. so If we specify 'invalid' path such as `/path/to.yaml`, this would crash.

This P/R fixes the problem by adding trailing `#/` if it is missing. Paths like `/path/to.yaml` will be parsed as `/path/to.yaml#/`.