### PR TITLE
Make the 'filewatcher' rubygem optional

### DIFF
--- a/lib/yaml_ref_resolver/cli.rb
+++ b/lib/yaml_ref_resolver/cli.rb
@@ -1,7 +1,11 @@
 require "yaml_ref_resolver"
 require "json"
 require "optparse"
-require "filewatcher"
+
+begin
+  require "filewatcher"
+rescue => LoadError
+end
 
 class YamlRefResolver
   class CLI
@@ -79,7 +83,11 @@ class YamlRefResolver
         @key = key
       end
 
-      @opt.on('-w', '--watch', 'glob pattern to watch cahnges') do
+      @opt.on('-w', '--watch', 'glob pattern to watch changes (needs filewatcher rubygem)') do
+        unless defined? FileWatcher
+          puts 'you need the `filewatcher` rubgem to watch for changes. You can run `gem install filewatcher` to install it.'
+          exit 1
+        end
         @watch = true
       end
 

--- a/lib/yaml_ref_resolver/cli.rb
+++ b/lib/yaml_ref_resolver/cli.rb
@@ -85,7 +85,7 @@ class YamlRefResolver
 
       @opt.on('-w', '--watch', 'glob pattern to watch changes (needs filewatcher rubygem)') do
         unless defined? FileWatcher
-          puts 'you need the `filewatcher` rubgem to watch for changes. You can run `gem install filewatcher` to install it.'
+          puts 'you need the `filewatcher` rubygem to watch for changes. You can run `gem install filewatcher` to install it.'
           exit 1
         end
         @watch = true

--- a/yaml_ref_resolver.gemspec
+++ b/yaml_ref_resolver.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency "filewatcher", "~> 1"
-
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
Tell about the missing dependency if filewatcher is not installed and the --watch option is used
This makes the library lighter if the CLI / watch feature is not needed

I'd like to use yaml_ref_resolver in a rubygem, but I don't want to bring "filewatcher" and it's dependencies. Would this PR be okay with you?