### PR TITLE
Support $ref with special characters / and ~

### DIFF
--- a/lib/yaml_ref_resolver/ref.rb
+++ b/lib/yaml_ref_resolver/ref.rb
@@ -18,7 +18,13 @@ class YamlRefResolver::Ref
   end
 
   def target_keys
-    @target_level.split("/").reject {|s| s == "" }
+    @target_level
+      .split("/")
+      .reject {|s| s == "" }
+      .each do |o|
+        o.gsub!("~1", "/")
+        o.gsub!("~0", "~")
+      end
   end
 end
 

--- a/test/yaml_ref_resolver_test.rb
+++ b/test/yaml_ref_resolver_test.rb
@@ -63,4 +63,11 @@ class YamlRefResolverTest < Minitest::Test
     assert_equal yaml['produces'][0], 'application/json'
     assert_equal yaml['produces'][1], 'text/html'
   end
+
+  def test_resolve_yaml_containing_special_characters_ref
+    path = File.join(File.dirname(__FILE__), *%w[yamls special_characters index.yaml])
+    yaml = @resolver.resolve!(path)
+
+    assert_equal yaml['paths']['/test~products/{name}']['post']['parameters'][0]['name'], 'name'
+  end
 end

--- a/test/yamls/special_characters/index.yaml
+++ b/test/yamls/special_characters/index.yaml
@@ -10,5 +10,5 @@ basePath: /v1
 produces:
   - application/json
 paths:
-  /products:
-    $ref: ./paths/products.yaml#/
+  /test~products/{name}:
+    $ref: ./paths/products.yaml#/~1test~0products~1{name}

--- a/test/yamls/special_characters/paths/products.yaml
+++ b/test/yamls/special_characters/paths/products.yaml
@@ -1,0 +1,29 @@
+  /test~products/{name}:
+    post:
+      tags:
+        - product
+      summary: Create a new product
+      parameters:
+        - in: query
+          name: name
+          required: true
+          schema:
+            type: string
+        - in: body
+          name: product
+          required: true
+          schema:
+            type: object
+            properties:
+              price:
+                type: integer
+      responses:
+        201:
+          description: Successfully created.
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              price:
+                type: integer


### PR DESCRIPTION
Hey @Joe-noh 
Thank you for the great work on that gem !

According to this [RFC on JavaScript Object Notation (JSON) Pointer](https://datatracker.ietf.org/doc/html/rfc6901)


> A JSON Pointer is a Unicode string (see [RFC4627], Section 3) containing a sequence of zero or more reference tokens, each prefixed by a '/' (%x2F) character. Because the characters `~` (%x7E) and `/` (%x2F) have special meanings in JSON Pointer, `~` needs to be encoded as `~0` and `/` needs to be encoded as `~1` when these characters appear in a reference token.


So I added support for it in this PR