### PR TITLE
Error names should be next to `rescue`

### DIFF
--- a/lib/yaml_ref_resolver/cli.rb
+++ b/lib/yaml_ref_resolver/cli.rb
@@ -4,7 +4,7 @@ require "optparse"
 
 begin
   require "filewatcher"
-rescue => LoadError
+rescue LoadError
 end
 
 class YamlRefResolver


### PR DESCRIPTION
When filewatcher is not found, exe/yaml_ref_resolver raises `LoadError` because the error is not rescued properly:

```
$ exe/yaml_ref_resolver 
<internal:/Users/kymmt90/.rbenv/versions/3.1.0/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- filewatcher (LoadError)
	from <internal:/Users/kymmt90/.rbenv/versions/3.1.0/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /Users/kymmt90/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/yaml_ref_resolver-0.7.0/lib/yaml_ref_resolver/cli.rb:6:in `<top (required)>'
	from <internal:/Users/kymmt90/.rbenv/versions/3.1.0/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:160:in `require'
	from <internal:/Users/kymmt90/.rbenv/versions/3.1.0/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:160:in `rescue in require'
	from <internal:/Users/kymmt90/.rbenv/versions/3.1.0/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:149:in `require'
	from exe/yaml_ref_resolver:3:in `<main>'
<internal:/Users/kymmt90/.rbenv/versions/3.1.0/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- yaml_ref_resolver/cli (LoadError)
	from <internal:/Users/kymmt90/.rbenv/versions/3.1.0/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from exe/yaml_ref_resolver:3:in `<main>'
```

exe/yaml_ref_resolver displays the correct message if this patch is applied:

```
$ exe/yaml_ref_resolver
please specify input yaml with --input option
```